### PR TITLE
ci: Job to auto-sync upstream changes

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,0 +1,20 @@
+on:
+  schedule:
+  - cron:  "*/15 * * * *"
+  workflow_dispatch:
+
+jobs:
+  repo-sync:
+    name: Sync changes from upstream bellperson
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - name: repo-sync
+      uses: repo-sync/github-sync@v2
+      with:
+        source_repo: "https://github.com/filecoin-project/bellperson.git"
+        source_branch: "master"
+        destination_branch: "master"
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add a GitHub workflow for syncing upstream bellperson updates
- Set sync to occur every 15 minutes or on manual triggers
- not on the main branch because otherwise this would be overwritten on every sync